### PR TITLE
Updated server requirements

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,7 +3,6 @@
 'use strict';
 
 var http = require('http'),
-    querystring = require('querystring'),
     mjml2html = require('mjml'),
     program = require('commander');
 
@@ -17,9 +16,8 @@ http.createServer(function (req, res) {
   res.writeHead(200, {'Content-Type': 'text/html'});
 
   req.on("data",function(data){
-    var params = querystring.parse(data.toString());
     try {
-      var result = mjml2html(params.mjml || '');
+      var result = mjml2html(data.toString() || '');
       res.write(result.html);
     } catch(ex) {
       res.write('');


### PR DESCRIPTION
Instead of requiring 'mjml' as a key for request body, this makes the
whole body the mjml template.
To get a html response, you may request this way:
`curl http://127.0.0.1:1410 -d "<mjml></mjml>"`

Fixes #3 